### PR TITLE
solve conflict with PORT macro

### DIFF
--- a/src/platforms/arm/d51/fastpin_arm_d51.h
+++ b/src/platforms/arm/d51/fastpin_arm_d51.h
@@ -34,23 +34,23 @@ public:
     inline static void setOutput() { pinMode(PIN, OUTPUT); } // TODO: perform MUX config { _PDDR::r() |= _MASK; }
     inline static void setInput() { pinMode(PIN, INPUT); } // TODO: preform MUX config { _PDDR::r() &= ~_MASK; }
 
-    inline static void hi() __attribute__ ((always_inline)) { PORT->Group[_GRP].OUTSET.reg = _MASK; }
-    inline static void lo() __attribute__ ((always_inline)) { PORT->Group[_GRP].OUTCLR.reg = _MASK; }
-    inline static void set(FASTLED_REGISTER port_t val) __attribute__ ((always_inline)) { PORT->Group[_GRP].OUT.reg = val; }
+    inline static void hi() __attribute__ ((always_inline)) { FASTLED_PORT->Group[_GRP].OUTSET.reg = _MASK; }
+    inline static void lo() __attribute__ ((always_inline)) { FASTLED_PORT->Group[_GRP].OUTCLR.reg = _MASK; }
+    inline static void set(FASTLED_REGISTER port_t val) __attribute__ ((always_inline)) { FASTLED_PORT->Group[_GRP].OUT.reg = val; }
 
     inline static void strobe() __attribute__ ((always_inline)) { toggle(); toggle(); }
 
-    inline static void toggle() __attribute__ ((always_inline)) { PORT->Group[_GRP].OUTTGL.reg = _MASK; }
+    inline static void toggle() __attribute__ ((always_inline)) { FASTLED_PORT->Group[_GRP].OUTTGL.reg = _MASK; }
 
     inline static void hi(FASTLED_REGISTER port_ptr_t port) __attribute__ ((always_inline)) { hi(); }
     inline static void lo(FASTLED_REGISTER port_ptr_t port) __attribute__ ((always_inline)) { lo(); }
     inline static void fastset(FASTLED_REGISTER port_ptr_t port, FASTLED_REGISTER port_t val) __attribute__ ((always_inline)) { *port = val; }
 
-    inline static port_t hival() __attribute__ ((always_inline)) { return PORT->Group[_GRP].OUT.reg | _MASK; }
-    inline static port_t loval() __attribute__ ((always_inline)) { return PORT->Group[_GRP].OUT.reg & ~_MASK; }
-    inline static port_ptr_t port() __attribute__ ((always_inline)) { return &PORT->Group[_GRP].OUT.reg; }
-    inline static port_ptr_t sport() __attribute__ ((always_inline)) { return &PORT->Group[_GRP].OUTSET.reg; }
-    inline static port_ptr_t cport() __attribute__ ((always_inline)) { return &PORT->Group[_GRP].OUTCLR.reg; }
+    inline static port_t hival() __attribute__ ((always_inline)) { return FASTLED_PORT->Group[_GRP].OUT.reg | _MASK; }
+    inline static port_t loval() __attribute__ ((always_inline)) { return FASTLED_PORT->Group[_GRP].OUT.reg & ~_MASK; }
+    inline static port_ptr_t port() __attribute__ ((always_inline)) { return &FASTLED_PORT->Group[_GRP].OUT.reg; }
+    inline static port_ptr_t sport() __attribute__ ((always_inline)) { return &FASTLED_PORT->Group[_GRP].OUTSET.reg; }
+    inline static port_ptr_t cport() __attribute__ ((always_inline)) { return &FASTLED_PORT->Group[_GRP].OUTCLR.reg; }
     inline static port_t mask() __attribute__ ((always_inline)) { return _MASK; }
 };
 

--- a/src/platforms/arm/renesas/fastpin_arm_renesas.h
+++ b/src/platforms/arm/renesas/fastpin_arm_renesas.h
@@ -23,7 +23,7 @@ public:
     typedef volatile uint16_t * port_ptr_t;
     typedef uint16_t port_t;
 
-    #define PORT ((R_PORT0_Type*)(_PORT))
+    #define FASTLED_PORT ((R_PORT0_Type*)(_PORT))
     #define digitalBspPinToPort(P)		   (P >> 8)
     #define digitalBspPinToBitMask(P)      (1 << (P & 0xFF))
 
@@ -41,28 +41,28 @@ public:
     inline static void setOutput() { pinMode(PIN, OUTPUT); } // TODO: perform MUX config { _PDDR::r() |= _MASK; }
     inline static void setInput() { pinMode(PIN, INPUT); } // TODO: preform MUX config { _PDDR::r() &= ~_MASK; }
 
-    inline static void hi() __attribute__ ((always_inline)) { PORT->POSR = digitalBspPinToBitMask(bspPin); }
-    inline static void lo() __attribute__ ((always_inline)) { PORT->PORR = digitalBspPinToBitMask(bspPin); }
-    inline static void set(FASTLED_REGISTER port_t val) __attribute__ ((always_inline)) { PORT->PODR = val; }
+    inline static void hi() __attribute__ ((always_inline)) { FASTLED_PORT->POSR = digitalBspPinToBitMask(bspPin); }
+    inline static void lo() __attribute__ ((always_inline)) { FASTLED_PORT->PORR = digitalBspPinToBitMask(bspPin); }
+    inline static void set(FASTLED_REGISTER port_t val) __attribute__ ((always_inline)) { FASTLED_PORT->PODR = val; }
 
     inline static void strobe() __attribute__ ((always_inline)) { toggle(); toggle(); }
 
-    inline static void toggle() __attribute__ ((always_inline)) { PORT->PODR & digitalBspPinToBitMask(bspPin) ? lo() : hi(); }
+    inline static void toggle() __attribute__ ((always_inline)) { FASTLED_PORT->PODR & digitalBspPinToBitMask(bspPin) ? lo() : hi(); }
 
     inline static void hi(FASTLED_REGISTER port_ptr_t port) __attribute__ ((always_inline)) { hi(); }
     inline static void lo(FASTLED_REGISTER port_ptr_t port) __attribute__ ((always_inline)) { lo(); }
     inline static void fastset(FASTLED_REGISTER port_ptr_t port, FASTLED_REGISTER port_t val) __attribute__ ((always_inline)) { *port = val; }
 
-    inline static port_t hival() __attribute__ ((always_inline)) { return PORT->PODR | digitalBspPinToBitMask(bspPin); }
-    inline static port_t loval() __attribute__ ((always_inline)) { return PORT->PODR & ~digitalBspPinToBitMask(bspPin); }
-    inline static port_ptr_t port() __attribute__ ((always_inline)) { return &PORT->PODR; }
-    inline static port_ptr_t sport() __attribute__ ((always_inline)) { return &PORT->POSR; }
-    inline static port_ptr_t cport() __attribute__ ((always_inline)) { return &PORT->PORR; }
+    inline static port_t hival() __attribute__ ((always_inline)) { return FASTLED_PORT->PODR | digitalBspPinToBitMask(bspPin); }
+    inline static port_t loval() __attribute__ ((always_inline)) { return FASTLED_PORT->PODR & ~digitalBspPinToBitMask(bspPin); }
+    inline static port_ptr_t port() __attribute__ ((always_inline)) { return &FASTLED_PORT->PODR; }
+    inline static port_ptr_t sport() __attribute__ ((always_inline)) { return &FASTLED_PORT->POSR; }
+    inline static port_ptr_t cport() __attribute__ ((always_inline)) { return &FASTLED_PORT->PORR; }
     inline static port_t mask() __attribute__ ((always_inline)) { return digitalBspPinToBitMask(bspPin); }
 
 };
 
-#define _FL_DEFPIN(PIN, bspPin, PORT) template<> class FastPin<PIN> : public _ARMPIN<PIN, bspPin, PORT> {};
+#define _FL_DEFPIN(PIN, bspPin, FASTLED_PORT) template<> class FastPin<PIN> : public _ARMPIN<PIN, bspPin, FASTLED_PORT> {};
 
 // Actual pin definitions
 #if defined(ARDUINO_UNOR4_WIFI)

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -209,7 +209,7 @@ protected:
 				[e0] "r" (e0),							\
 				[e1] "r" (e1),							\
 				[e2] "r" (e2),							\
-				[PORT] ASM_VAR_PORT,                    \
+				[FASTLED_PORT] ASM_VAR_PORT,                    \
 				[O0] "M" (RGB_BYTE0(RGB_ORDER)),		\
 				[O1] "M" (RGB_BYTE1(RGB_ORDER)),		\
 				[O2] "M" (RGB_BYTE2(RGB_ORDER))		\
@@ -226,9 +226,9 @@ protected:
 
 // Note: the code in the else in HI1/LO1 will be turned into an sts (2 cycle, 2 word)
 // 1 cycle, write hi to the port
-#define HI1 FASTLED_SLOW_CLOCK_ADJUST if((int)(FastPin<DATA_PIN>::port())-0x20 < 64) { asm __volatile__("out %[PORT], %[hi]" ASM_VARS ); } else { *FastPin<DATA_PIN>::port()=hi; }
+#define HI1 FASTLED_SLOW_CLOCK_ADJUST if((int)(FastPin<DATA_PIN>::port())-0x20 < 64) { asm __volatile__("out %[FASTLED_PORT], %[hi]" ASM_VARS ); } else { *FastPin<DATA_PIN>::port()=hi; }
 // 1 cycle, write lo to the port
-#define LO1 if((int)(FastPin<DATA_PIN>::port())-0x20 < 64) { asm __volatile__("out %[PORT], %[lo]" ASM_VARS ); } else { *FastPin<DATA_PIN>::port()=lo; }
+#define LO1 if((int)(FastPin<DATA_PIN>::port())-0x20 < 64) { asm __volatile__("out %[FASTLED_PORT], %[lo]" ASM_VARS ); } else { *FastPin<DATA_PIN>::port()=lo; }
 
 #endif
 

--- a/src/platforms/avr/fastpin_avr.h
+++ b/src/platforms/avr/fastpin_avr.h
@@ -55,8 +55,8 @@ typedef volatile uint8_t & reg8_t;
 #if defined(AVR_ATtinyxy7) || defined(AVR_ATtinyxy6) || defined(AVR_ATtinyxy4) || defined(AVR_ATtinyxy2)
 
 // ATtiny series 0/1 and ATmega series 0
-#define _FL_IO(L,C) _RD8(PORT ## L ## _DIR); _RD8(PORT ## L ## _OUT); _RD8(PORT ## L ## _IN); _FL_DEFINE_PORT3(L, C, _R(PORT ## L ## _OUT));
-#define _FL_DEFPIN(_PIN, BIT, L) template<> class FastPin<_PIN> : public _AVRPIN<_PIN, 1<<BIT, _R(PORT ## L ## _OUT), _R(PORT ## L ## _DIR), _R(PORT ## L ## _IN)> {};
+#define _FL_IO(L,C) _RD8(FASTLED_PORT ## L ## _DIR); _RD8(FASTLED_PORT ## L ## _OUT); _RD8(FASTLED_PORT ## L ## _IN); _FL_DEFINE_PORT3(L, C, _R(FASTLED_PORT ## L ## _OUT));
+#define _FL_DEFPIN(_PIN, BIT, L) template<> class FastPin<_PIN> : public _AVRPIN<_PIN, 1<<BIT, _R(FASTLED_PORT ## L ## _OUT), _R(FASTLED_PORT ## L ## _DIR), _R(FASTLED_PORT ## L ## _IN)> {};
 
 #elif defined(__AVR_ATmega4809__)
 
@@ -67,8 +67,8 @@ typedef volatile uint8_t & reg8_t;
 #else
 
 // Others
-#define _FL_IO(L,C) _RD8(DDR ## L); _RD8(PORT ## L); _RD8(PIN ## L); _FL_DEFINE_PORT3(L, C, _R(PORT ## L));
-#define _FL_DEFPIN(_PIN, BIT, L) template<> class FastPin<_PIN> : public _AVRPIN<_PIN, 1<<BIT, _R(PORT ## L), _R(DDR ## L), _R(PIN ## L)> {};
+#define _FL_IO(L,C) _RD8(DDR ## L); _RD8(FASTLED_PORT ## L); _RD8(PIN ## L); _FL_DEFINE_PORT3(L, C, _R(FASTLED_PORT ## L));
+#define _FL_DEFPIN(_PIN, BIT, L) template<> class FastPin<_PIN> : public _AVRPIN<_PIN, 1<<BIT, _R(FASTLED_PORT ## L), _R(DDR ## L), _R(PIN ## L)> {};
 #endif
 
 // Pre-do all the port definitions


### PR DESCRIPTION
`PORT` macro defined in FastLED conflicts with a struct defined in [ArduinoCore-renesas](https://github.com/arduino/ArduinoCore-renesas), which is used for example [in Arduino_LED_Matrix](https://github.com/arduino/ArduinoCore-renesas/blob/main/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h#L116), causing a compilation error.